### PR TITLE
feat: scaffold basic HTTP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories
+.bower_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# InflueZone / BenimDükkanım Skeleton Server
+
+This repository contains a minimal Node.js HTTP server that sketches core endpoints for the InflueZone and BenimDükkanım projects. Each endpoint returns placeholder JSON data that represents the structure of future features.
+
+## Available Endpoints
+
+- `GET /influezone/health` – basic health check for the InflueZone API
+- `GET /influezone/dashboard` – placeholder for the influencer dashboard
+- `GET /benimdukkanim/health` – health check for the BenimDükkanım API
+- `GET /benimdukkanim/store` – placeholder for the store home page
+
+## Development
+
+Start the server:
+
+```bash
+npm start
+```
+
+Run tests:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "influezone",
+  "version": "1.0.0",
+  "description": "Skeleton server for InflueZone and BenimDükkanım",
+  "main": "src/server.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,46 @@
+const http = require('http');
+const url = require('url');
+
+function createServer() {
+  return http.createServer((req, res) => {
+    const parsedUrl = url.parse(req.url, true);
+    const { pathname } = parsedUrl;
+
+    const sendJSON = (status, data) => {
+      const body = JSON.stringify(data);
+      res.writeHead(status, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body)
+      });
+      res.end(body);
+    };
+
+    // InflueZone routes
+    if (pathname === '/influezone/health' && req.method === 'GET') {
+      return sendJSON(200, { status: 'InflueZone API healthy' });
+    }
+    if (pathname === '/influezone/dashboard' && req.method === 'GET') {
+      return sendJSON(200, { message: 'Influencer dashboard placeholder' });
+    }
+
+    // BenimDükkanım routes
+    if (pathname === '/benimdukkanim/health' && req.method === 'GET') {
+      return sendJSON(200, { status: 'BenimDükkanım API healthy' });
+    }
+    if (pathname === '/benimdukkanim/store' && req.method === 'GET') {
+      return sendJSON(200, { message: 'Store homepage placeholder' });
+    }
+
+    // Not Found
+    sendJSON(404, { error: 'Not found' });
+  });
+}
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  createServer().listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+module.exports = { createServer };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { createServer } = require('../src/server');
+
+function startServer() {
+  const server = createServer();
+  return new Promise(resolve => {
+    server.listen(0, () => resolve(server));
+  });
+}
+
+function stopServer(server) {
+  return new Promise(resolve => server.close(resolve));
+}
+
+test('influezone health endpoint', async () => {
+  const server = await startServer();
+  const { port } = server.address();
+  const res = await fetch(`http://localhost:${port}/influezone/health`);
+  const json = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.deepStrictEqual(json, { status: 'InflueZone API healthy' });
+  await stopServer(server);
+});
+
+test('benimdukkanim store endpoint', async () => {
+  const server = await startServer();
+  const { port } = server.address();
+  const res = await fetch(`http://localhost:${port}/benimdukkanim/store`);
+  const json = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.deepStrictEqual(json, { message: 'Store homepage placeholder' });
+  await stopServer(server);
+});


### PR DESCRIPTION
## Summary
- add minimal Node.js server with placeholder routes for InflueZone and BenimDükkanım
- include tests using built-in `node:test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977bf119b48333b38719ebaf9ff74b