### PR TITLE
fix: ensure deployment uses correct artifact path

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: node-app
-        path: .
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
   deploy:
     permissions:
@@ -68,6 +68,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: node-app
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
     - name: 'Deploy to Azure WebApp'
       id: deploy-to-webapp


### PR DESCRIPTION
## Summary
- align artifact upload and download paths in Azure Web App workflow to use AZURE_WEBAPP_PACKAGE_PATH

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689779a555c48333a68768c99ab059d8